### PR TITLE
remove configuration of aws_s3_bucket_acl as this is no longer required

### DIFF
--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -117,12 +117,6 @@ data "aws_iam_policy_document" "bucket_policy_doc_replication_bucket" {
   }
 }
 
-resource "aws_s3_bucket_acl" "replication_bucket_acl" {
-  provider = aws.replication
-  bucket   = aws_s3_bucket.replication_bucket.id
-  acl      = "private"
-}
-
 resource "aws_s3_bucket_versioning" "replication_bucket_versioning" {
   provider = aws.replication
   bucket   = aws_s3_bucket.replication_bucket.id
@@ -194,11 +188,6 @@ data "aws_iam_policy_document" "bucket_policy_doc_codepipeline_bucket" {
       "${aws_s3_bucket.codepipeline_bucket.arn}/*",
     ]
   }
-}
-
-resource "aws_s3_bucket_acl" "codepipeline_bucket_acl" {
-  bucket = aws_s3_bucket.codepipeline_bucket.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_versioning" "codepipeline_bucket_versioning" {


### PR DESCRIPTION
…ed as ACLs are disabled by default.

*Issue #, if available:*
Terraform Error: The bucket does not allow ACLs #12


*Description of changes:*
As described in the issue, terraform gives an error when including the resource aws_s3_bucket_acl in an S3 bucket. Creating this PR to remove the code so the end users dont face any issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
